### PR TITLE
Support creating of named keys.

### DIFF
--- a/outline_vpn/outline_vpn.py
+++ b/outline_vpn/outline_vpn.py
@@ -67,12 +67,12 @@ class OutlineVPN:
             return result
         raise Exception("Unable to retrieve keys")
 
-    def create_key(self) -> OutlineKey:
+    def create_key(self, key_name=None) -> OutlineKey:
         """Create a new key"""
         response = requests.post(f"{self.api_url}/access-keys/", verify=False)
         if response.status_code == 201:
             key = response.json()
-            return OutlineKey(
+            outline_key = OutlineKey(
                 key_id=key.get("id"),
                 name=key.get("name"),
                 password=key.get("password"),
@@ -81,6 +81,10 @@ class OutlineVPN:
                 access_url=key.get("accessUrl"),
                 used_bytes=0,
             )
+            if key_name:
+                if self.rename_key(outline_key.key_id, key_name):
+                    outline_key.name = key_name
+            return outline_key
 
         raise Exception("Unable to create key")
 

--- a/outline_vpn/outline_vpn.py
+++ b/outline_vpn/outline_vpn.py
@@ -81,9 +81,8 @@ class OutlineVPN:
                 access_url=key.get("accessUrl"),
                 used_bytes=0,
             )
-            if key_name:
-                if self.rename_key(outline_key.key_id, key_name):
-                    outline_key.name = key_name
+            if key_name and self.rename_key(outline_key.key_id, key_name):
+                outline_key.name = key_name
             return outline_key
 
         raise Exception("Unable to create key")

--- a/test_outline_vpn.py
+++ b/test_outline_vpn.py
@@ -36,6 +36,9 @@ def test_cud_key(client: OutlineVPN):  # pylint: disable=W0621
     assert new_key is not None
     assert int(new_key.key_id) > 0
 
+    named_key = client.create_key(key_name="Test Key")
+    assert named_key.name == "Test Key"
+
     assert client.rename_key(new_key.key_id, "a_name")
 
     assert client.delete_key(new_key.key_id)


### PR DESCRIPTION
Thanks for a very easy-to-use package.

I had a specific problem where I needed to have named keys e.g While creating a key for a user with email `test@gmail.com` I needed to be able to name the key using this email.

This PR allows a user to optionally specify the key name while creating the key.
