### PR TITLE
Deprecate the use of the library without passing a certificate hash

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="outline-vpn-api",
-    version="4.1.0",
+    version="5.0.0",
     packages=["outline_vpn"],
     url="https://github.com/jadolg/outline-vpn-api/",
     license="MIT",

--- a/test_outline_vpn.py
+++ b/test_outline_vpn.py
@@ -7,7 +7,7 @@ import re
 
 import pytest
 
-from outline_vpn.outline_vpn import OutlineVPN
+from outline_vpn.outline_vpn import OutlineVPN, OutlineLibraryException
 
 
 @pytest.fixture
@@ -22,6 +22,12 @@ def client() -> OutlineVPN:
         api_url=api_url, cert_sha256=api_data.get("certSha256"))
 
     return client
+
+
+def test_no_cert_sha256_raises_exception():
+    """Test that the client raises an exception if the cert sha256 is not provided"""
+    with pytest.raises(OutlineLibraryException):
+        OutlineVPN(api_url="https://aaa", cert_sha256="")
 
 
 def test_get_keys(client: OutlineVPN):  # pylint: disable=W0621


### PR DESCRIPTION
Using this wrapper without specifying the certificate fingerprint is insecure because that's the only way to verify that the server is the correct one.
Before https://github.com/jadolg/outline-vpn-api/issues/10, we were not even doing any validation but that changed because of the security concerns. We decided not to remove it immediately and do a controlled full version bump when it made sense.
- Stop allowing the usage of the library without certificate
- Bump version to 5.0.0
